### PR TITLE
Update requirement

### DIFF
--- a/requirements
+++ b/requirements
@@ -6,6 +6,5 @@ statsmodels
 pomegranate
 scikit-learn
 scikit-image
-pytorch
-sparse
+sparse>=0.9.1
 ipdb


### PR DESCRIPTION
为 sparse 添加了 >=0.9.1 的约束
去掉了 pytorch 的约束（默认是 CPU 计算，不应该安装时直接安装 pytorch，用户有 GPU 计算需求时再安装即可）