### PR TITLE
fix time tensor bug

### DIFF
--- a/spartan/tensor/tensor.py
+++ b/spartan/tensor/tensor.py
@@ -17,7 +17,7 @@ from joblib import Parallel, delayed
 class TensorData:
     def __init__(self, data: pd.DataFrame):
         self.data = data
-        self.labels = data.columns[1:]
+        self.labels = data.columns
 
     def toDTensor(self, hastticks: bool = True):
         if hastticks:

--- a/spartan/tensor/timeseries.py
+++ b/spartan/tensor/timeseries.py
@@ -53,11 +53,11 @@ class Timeseries:
         if labels is None:
             self.labels = ['dim_' + str(i) for i in range(self.dimension)]
         else:
-            self.labels = labels
+            self.labels = list(labels)
         if time_tensor is None:
             self.startts = startts
             import numpy as np
-            self.time_tensor = DTensor.from_numpy(np.linspace(self.startts, 1 / self.freq * self.length + self.startts, self.length))
+            self.time_tensor = self.__init_time(self.val_tensor.shape[1], self.freq, self.startts)
         else:
             self.startts = time_tensor[0]
             self.freq = (self.length) / (time_tensor.max() - time_tensor.min())
@@ -92,8 +92,10 @@ class Timeseries:
             Start Timestamp: {round(self.startts, 3)}
             Labels: {', '.join([str(x) for x in self.labels])}
         """
+        columns = ['Time']
+        columns.extend(self.labels)
         print(pd.DataFrame(DTensor([self.time_tensor]).concatenate(self.val_tensor, axis=0)._data.T,
-                           columns=['Time'] + self.labels))
+                           columns=columns))
         return _str
 
     def __copy__(self):
@@ -616,8 +618,31 @@ class Timeseries:
         startts : int
             start time tick
         """
-        import numpy as np
         _len = val_tensor.shape[1]
         self.length = _len
-        self.time_tensor = DTensor.from_numpy(np.linspace(startts, 1 / freq * _len + startts, _len))
+        self.time_tensor = self.__init_time(_len, freq, startts)
         self.freq = freq
+    
+    
+    def __init_time(self, len: int, freq: int, startts: int):
+        """Construct time tensor.
+
+        Parameters
+        ----------
+        len : int
+            length of time tensor
+
+        freq : int
+            frequency of series
+
+        startts : int
+            start time tick
+        
+        Returns
+        ----------
+        time_tensor : DTensor
+            time tensor
+        """
+        import numpy as np
+        time_tensor = DTensor.from_numpy(np.linspace(startts, 1 / freq * len + startts - 1, len))
+        return time_tensor


### PR DESCRIPTION
1. In the last version, if time tensor is not given, it will be constructed incorrectly with one point missed. I add ```__init_time``` function to construct time tensor used in two places ```__init__``` and ```__update_time```

2. Update labels of time series objects. Now it will cast the parameter ```label``` into ```list``` type.

3. Fix the bug that when printing a time series object, labels will be shown in ```Time[labels]``` format. Now ```Time``` and labels will be shown in separate columns.

4. Tensor data will now extract all labels instead of eliminating the first one [which is believed as the label of time] by default.