### PR TITLE
dtype-bug-fix

### DIFF
--- a/spartan/model/CubeFlow/util.py
+++ b/spartan/model/CubeFlow/util.py
@@ -54,7 +54,7 @@ def preprocess_data(stensorList:list, dim):
             if map_m not in mt_t_dict:
                 mt_t_dict[map_m] = mt % m_shape_a
             key = (a, map_m)
-            concise_a_mt_dict[key] += elem
+            concise_a_mt_dict[key] += elem # may produce error: unsupported operand type(s) for +=: 'int' and 'str'
         print('time:', time.time() - stt)
         for c, mt, elem in zip(c_mt_nnz[0], c_mt_nnz[1], c_mt_coo.data):
             if mt not in mt_dict:

--- a/spartan/tensor/tensor.py
+++ b/spartan/tensor/tensor.py
@@ -44,7 +44,11 @@ class TensorData:
                 else:
                     colind = mappers[i].map(self.data.iloc[:, i])
                     attr.iloc[:, i] = colind
-        attr = attr.astype('int')
+        # the dtype bug may better fixed through pre-judge data range and set the dtype 
+        # astype here also cause the loadTensor(...,idx_types = ) meanless?
+        # finally change the spartan/util/ioutil.py  def transfer_type(typex): add the np.int64 and np.float64
+        #attr = attr.astype('int64') #astype to int when dimension：（a1,a2,a3） is large especially when a2*a3>INT_MAX,it will cause C int cannot to long 
+        #value = value.astype('float64') #fix the bug in cubeflow/util.py line 57
         return STensor((attr.to_numpy().T, value.to_numpy()))
         
 

--- a/spartan/util/ioutil.py
+++ b/spartan/util/ioutil.py
@@ -33,6 +33,10 @@ class File():
             _typex = 'int'
         elif typex == str:
             _typex = 'object'
+        elif typex == np.int64:
+            _typex = np.int64
+        elif typex == np.float64:
+            _typex = np.float64
         else:
             _typex = 'object'
         return _typex


### PR DESCRIPTION
in spartan/tensor/tensor.py line 47
#attr = attr.astype('int64') #astype to int when dimension：（a1,a2,a3） is large especially when a2*a3>INT_MAX,it will cause C int cannot to long 
#value = value.astype('float64') #fix the bug in cubeflow/util.py line 57

attr = attr.astype here also cause the loadTensor(...,idx_types = ) meanless?
finally I think change the spartan/util/ioutil.py  def transfer_type(typex): (add the np.int64 and np.float64) will fix the problem above
