### PR TITLE
Fix namespace bug of module names.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools.extension import Extension
 from Cython.Build import cythonize, build_ext
 
 NAME = 'spartan2'
-VERSION = '0.1.3'
+VERSION = '0.1.3-post2'
 DESCRIPTION = 'collection of data mining algorithms on big graphs and time series'
 URL = 'https://github.com/BGT-M/spartan2'
 AUTHOR = 'Shenghua Liu, Houquan Zhou, Quan Ding, Jiabao Zhang, Xin Zhao, Siwei Zeng,etc'

--- a/spartan/model/__init__.py
+++ b/spartan/model/__init__.py
@@ -69,6 +69,6 @@ __all__ = [
     'IAT',
     'Fraudar',
     'CubeFlow',
-    'Specgreedy'
+    'Specgreedy',
     'CubeFlowPlus'
 ]


### PR DESCRIPTION
- A comma is missing between 'CubeFlowPlus' and 'SpecGreedy'.