### PR TITLE
Fix package name conflict on pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools.extension import Extension
 from Cython.Build import cythonize, build_ext
 
 NAME = 'spartan2'
-VERSION = '0.1.3-post3'
+VERSION = '0.1.3-post4'
 DESCRIPTION = 'collection of data mining algorithms on big graphs and time series'
 URL = 'https://github.com/BGT-M/spartan2'
 AUTHOR = 'Shenghua Liu, Houquan Zhou, Quan Ding, Jiabao Zhang, Xin Zhao, Siwei Zeng,etc'


### PR DESCRIPTION
Version number 0.1.3-post 3 is deprecated.

Using 0.1.3-post 4 instead.